### PR TITLE
Changing NodeJS(Javascript) to Javascript(NodeJS)

### DIFF
--- a/files/en-us/learn/server-side/first_steps/introduction/index.html
+++ b/files/en-us/learn/server-side/first_steps/introduction/index.html
@@ -87,7 +87,7 @@ tags:
 
 <p>Web developers can't control what browser every user might be using to view a website  — browsers provide inconsistent levels of compatibility with client-side code features, and part of the challenge of client-side programming is handling differences in browser support gracefully.</p>
 
-<p>Server-side code can be written in any number of programming languages — examples of popular server-side web languages include PHP, Python, Ruby, C#, and NodeJS (JavaScript). The server-side code has full access to the server operating system and the developer can choose what programming language (and specific version) they wish to use.</p>
+<p>Server-side code can be written in any number of programming languages — examples of popular server-side web languages include PHP, Python, Ruby, C#, and JavaScript (NodeJS). The server-side code has full access to the server operating system and the developer can choose what programming language (and specific version) they wish to use.</p>
 
 <p>Developers typically write their code using <strong>web frameworks</strong>. Web frameworks are collections of functions, objects, rules and other code constructs designed to solve common problems, speed up development, and simplify the different types of tasks faced in a particular domain.</p>
 


### PR DESCRIPTION
Issue in [<strong>Are server-side and client-side programming the same?</strong>](https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps/Introduction#are_server-side_and_client-side_programming_the_same): 
[...] examples of popular server-side web languages include PHP, Python, Ruby, C#, and NodeJS (JavaScript).[...]

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)
It is a good idea to replace "NodeJS (JavaScript)" by "JavaScript (NodeJS)". I see many people thinking NodeJS is a language. Node is a runtime. JavaScript is the language.

> MDN URL of main page changed
https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps/Introduction

> Issue number (if there is an associated issue)
#3568

> Anything else that could help us review it
